### PR TITLE
出欠判定の軽微な修正

### DIFF
--- a/next_app/src/app/api/attend/route.ts
+++ b/next_app/src/app/api/attend/route.ts
@@ -82,7 +82,7 @@ export async function POST(req: NextRequest) {
       const attendancehours = ((attendanceDate.getUTCHours() + 9) % 24) * 60;
       const attendanceminutes = attendanceDate.getMinutes();
 
-      // HH:MMをミリ秒に変換
+      // HH:MMを秒に変換
       const attendancemilliseconds = attendancehours + attendanceminutes; // HH:MMを秒に変換
       return attendancemilliseconds;
     };
@@ -95,7 +95,7 @@ export async function POST(req: NextRequest) {
       const Promisedhours = ((promisedDate.getUTCHours() + 9) % 24) * 60;
       const Promisedminutes = promisedDate.getMinutes();
 
-      // HH:MMをミリ秒に変換
+      // HH:MMを秒に変換
       const Promisedmilliseconds = Promisedhours + Promisedminutes;
       return Promisedmilliseconds;
     };
@@ -107,7 +107,10 @@ export async function POST(req: NextRequest) {
       latestPromisedTimeInMillis(attendanceRecord.latestPromisedTime)
     ) {
       status = "late"; // 出席時間が約束の時間より遅い場合
-    } else if (attendanceTimeInMillis <= latestPromisedTimeInMillis) {
+    } else if (
+      attendanceTimeInMillis(attendance.attendanceTime) <=
+      latestPromisedTimeInMillis(attendanceRecord.latestPromisedTime)
+    ) {
       status = "attendance"; // 出席時間が約束の時間と同じか早い場合
     }
 

--- a/next_app/src/app/history/[userId]/page.tsx
+++ b/next_app/src/app/history/[userId]/page.tsx
@@ -40,13 +40,13 @@ const formatDate = (dateString: string | Date) => {
 const JaStatus = (status: "attendance" | "late" | "absence" | "officialleave") => {
   switch (status) {
     case "attendance":
-      return "出席";
+      return <span style={{ color: "green" }}>出席</span>;
     case "late":
-      return "遅刻";
+      return <span style={{ color: "red" }}>遅刻</span>;
     case "absence":
       return "欠席";
     case "officialleave":
-      return "公欠";
+      return <span style={{ color: "orange" }}>公欠</span>;
   }
 };
 

--- a/next_app/src/app/history/[userId]/page.tsx
+++ b/next_app/src/app/history/[userId]/page.tsx
@@ -34,7 +34,7 @@ const formatDate = (dateString: string | Date) => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0"); // 月は0始まりなので+1
   const day = String(date.getDate()).padStart(2, "0"); // 2桁に整形
-  return `${year}-${month}-${day}`;
+  return `${year}/${month}/${day}`;
 };
 // ステータスを日本語に変換
 const JaStatus = (status: "attendance" | "late" | "absence" | "officialleave") => {


### PR DESCRIPTION
**やったこと**

- 出席遅刻を判定するとき、特定の時間の組み合わせでうまく処理されずステータスがabcense(欠席)となってしまう不具合を修正
- YYYY-MM-DD表記をYYYY/MM/DDに変更
- ステータスごと色を分け

**やらないこと**
- なし

 **できるようになること（ユーザ目線）**

- 履歴に登校が正確に記録される
-  YYYY/MM/DDと表示される
- 一目でステータスの状態が確認可能
![スクリーンショットstatus](https://github.com/user-attachments/assets/b6cd4db8-8c39-4651-b07b-e457c8cc53be)

**できなくなること（ユーザ目線）**

- なし

**動作確認**

- 自身のdocker環境でいくつかの新規ユーザを作成しそれぞれで不具合の発生した時間の設定を含めたあらゆるパターンを出席判定を実行、すべて想定通りの処理がなされた。

**その他**

- このブランチmerge後は削除していただいて構いません。