### PR TITLE
adminページで登録ボタンがポップアップの前面に表示されないようにした

### DIFF
--- a/next_app/src/app/admin/page.tsx
+++ b/next_app/src/app/admin/page.tsx
@@ -230,10 +230,10 @@ export default function Page() {
         <div
           className={`fixed inset-0 flex items-center justify-center ${
             isDarkMode ? "bg-black" : "bg-gray-500"
-          } bg-opacity-50`}
+          } bg-opacity-50 z-50`}
         >
           <div
-            className={`p-6 rounded shadow-lg  border border-gray-400 ${
+            className={`p-6 rounded shadow-lg border border-gray-400 ${
               isDarkMode ? "dark-mode-bg" : "bg-white"
             }`}
           >
@@ -254,7 +254,7 @@ export default function Page() {
             </div>
           </div>
         </div>
-      )}
+        )}
       <div style={tableContainerStyles}>
         {/* getTableProps 関数が返すオブジェクト内のすべてのプロパティと値が、<table> タグに個別のプロパティとして適用 */}
         <table {...getTableProps()} style={tableStyles}>


### PR DESCRIPTION
## やったこと

### adminページのバグを改善した
* 削除ボタンを押してポップアップを開いた時に登録ボタンがポップアップよりも前面に表示されるバグを改善した
* ポップアップのdivタグのclassnameに`z-50`を追加し、ポップアップの高さを高めに設定した

## やらないこと

* なし

## できるようになること（ユーザ目線）

* ポップアップが見やすくなる

## できなくなること（ユーザ目線）

* なし

## 動作確認

下の画像のように自分の環境ではポップアップと登録ボタンが重ならないため、バグが解消できたか確認できていません。

<img width="1440" alt="スクリーンショット 2024-10-24 14 19 55" src="https://github.com/user-attachments/assets/0987aae0-62fc-4aaf-860a-4d8c6d0e806e">



## その他

* ポップアップと確認ボタンが重なる環境の人が、確認ボタンがポップアップの前面にこないことを確認してからマージして欲しいです。