### PR TITLE
新規登録ページで目標時間を設定できるようにした

### DIFF
--- a/next_app/src/app/api/register/route.ts
+++ b/next_app/src/app/api/register/route.ts
@@ -2,27 +2,20 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma'; // Prismaを使用している場合のインポート例
 import bcrypt from 'bcrypt';
 
-async function registerUser(name: string, password: string, inputDateString: string | null) {
+async function registerUser(name: string, password: string, inputDateString: string) {
   // パスワードのハッシュ化
   const hashedPassword = await bcrypt.hash(password, 10);
+  console.log("目標時間", inputDateString)
 
-  // promisedTimeを検証
-  let promisedTime = null;
-  if (inputDateString) {
-    promisedTime = new Date(inputDateString);
-    // promisedTimeが無効な場合はエラーをスロー
-    if (isNaN(promisedTime.getTime())) {
-      throw new Error("Invalid Date provided for promisedTime");
-    }
-  }
-
-  // Prismaのcreateメソッドでユーザーを作成
-  const user = await prisma.user.create({
-    data: {
+  const user = {
       name: name,
       password: hashedPassword,
-      promisedTime: new Date(), // promisedTimeがnullでも良い場合はそのまま渡す
-    },
+      promisedTime: inputDateString, 
+  };
+
+    // Prismaのcreateメソッドでユーザーを作成
+  await prisma.user.create({
+    data: user,
   });
 
   return user;
@@ -39,7 +32,7 @@ export async function POST(request: Request) {
     }
 
     // promisedTimeがない場合はnullを設定
-    const user = await registerUser(name, password, promisedTime || null);
+    const user = await registerUser(name, password, promisedTime);
 
     // 受信したデータの確認
     console.log('Received:', { name, password, promisedTime });

--- a/next_app/src/app/register/page.tsx
+++ b/next_app/src/app/register/page.tsx
@@ -5,11 +5,17 @@ import axios from 'axios';
 import Button from '@/components/Button';
 import Header from '@/components/Header';
 import { FaSignInAlt } from 'react-icons/fa';
+import DrumTimePicker from "../../components/DrumTimePicker";
+import convertHMtoDatetime from "../../utils/convertHMtoDatetime";
+
+
 
 
 export default function RegisterPage() {
   const [name, setUserName] = useState('');
   const [password, setPassword] = useState('');
+  const [promisedTime, setPromisedTime] = useState("");
+
   const router = useRouter();
   const userId = '';
   const [isDisabled, setIsDisabled] = useState<boolean>(true);
@@ -19,6 +25,12 @@ export default function RegisterPage() {
   useEffect(() => {
     setIsDisabled(!(name && password)); // 両方のフィールドが入力されている場合にボタンを有効化
   }, [name, password]);
+
+  const handleTime = (hour: number, minute: number) => {
+    const time = convertHMtoDatetime(hour, minute);
+    setPromisedTime(time);
+  };
+
 
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -30,7 +42,7 @@ export default function RegisterPage() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ name, password }),
+        body: JSON.stringify({ name, password, promisedTime }),
       });
 
       if (res.ok) {
@@ -68,6 +80,10 @@ export default function RegisterPage() {
           onChange={(e) => setPassword(e.target.value)}
           className="mb-2 w-72 px-3 py-2 border border-gray-300 rounded"
         />
+        <div className="flex justify-center items-center gap-5">
+          <h2 className="text-lg ">目標時間</h2>
+          <DrumTimePicker handleTime={handleTime} />
+        </div>
         <Button type="submit" disabled={isDisabled || isLoading}>
           {isLoading ? "Loading..." : '登録'}
         </Button>


### PR DESCRIPTION
## やったこと
- 新規登録ページで目標時間を設定できるようにした
  - registerページのフロントエンドでページに目標時間を登録するタイムピッカーを表示させるようにした
  - registerページのバックエンドで目標時間をデータベースに登録できるようにした
## やらないこと

* なし

## できるようになること（ユーザ目線）

* 新規登録のページで目標時間を設定できるようになる

## できなくなること（ユーザ目線）

* なし

## 動作確認
* 新規登録ページは次のように表示されました

<img width="1440" alt="スクリーンショット 2024-10-30 10 04 43" src="https://github.com/user-attachments/assets/a1820f46-e352-4a77-bca3-ffe5f9c38461">

* 新規登録ページから新しいユーザーとユーザーの目標時間を登録し、そのユーザーにログインすると設定した目標時間が表示されていました。
